### PR TITLE
Download & Install Nim dlls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,10 +24,36 @@ inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
     required: false
+  install-dlls:
+    description: 'Install Nim DLLs on Windows'
+    default: 'true'
+    required: false
 
 runs:
   using: 'composite'
   steps:
+    - name: Cache Nim DLLs (Windows)
+      if: runner.os == 'Windows' && inputs.install-dlls == 'true'
+      uses: actions/cache@v4
+      id: cache-nim-dlls
+      with:
+        path: nim-dlls.zip
+        key: nim-dlls-${{ runner.os }}
+
+    - name: Download Nim DLLs (Windows)
+      if: runner.os == 'Windows' && inputs.install-dlls == 'true' && steps.cache-nim-dlls.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri https://nim-lang.org/download/dlls.zip -OutFile nim-dlls.zip
+
+    - name: Setup Nim DLLs (Windows)
+      if: runner.os == 'Windows' && inputs.install-dlls == 'true'
+      shell: pwsh
+      run: |
+        Expand-Archive -Path nim-dlls.zip -DestinationPath nim-dlls -Force
+        echo "$Env:GITHUB_WORKSPACE\nim-dlls" >> $Env:GITHUB_PATH
+        echo "SSL_CERT_FILE=$Env:GITHUB_WORKSPACE\nim-dlls\cacert.pem" >> $Env:GITHUB_ENV
+
     - name: Install nimble
       shell: bash
       run: |


### PR DESCRIPTION
Without this, the windows-latest runner was failing on my builds with:

```
Run nimble -v
  nimble -v
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
could not load: (libcrypto-1_1-x64|libeay64).dll
```

A GitHub search for this error shows a number of people encountering it https://github.com/search?q=%22could+not+load%3A+%28libcrypto-1_1-x64%7Clibeay64%29.dll%22+lang%3Anim&type=issues

Although it's not specific to setup-nimble-action, I think it makes sense to have this action work on Windows out of the box.